### PR TITLE
Handle Bugged Unconnected Players Rejoining Midround

### DIFF
--- a/pkg/demoscrape2/helpers.go
+++ b/pkg/demoscrape2/helpers.go
@@ -25,16 +25,44 @@ func getTeamMembers(team *common.TeamState, game *Game, p dem.Parser) []*common.
 	// Filter players by the Team from the team state
 	teamPlayers := make([]*common.Player, 0)
 
+	// Helper function to find player index in teamPlayers
+	findPlayerIndex := func(slice []*common.Player, steamId uint64) int {
+		for i, player := range slice {
+			if player.SteamID64 == steamId {
+				return i
+			}
+		}
+		return -1
+	}
+
 	for _, player := range players {
 		if player.Team == team.Team() {
+			if game.ConnectedAfterRoundStart[player.SteamID64] {
+				continue
+			}
 			teamPlayers = append(teamPlayers, player)
 		}
 	}
 
-	// Grab reconnected players
+	// Grab reconnected players and check for duplicates
 	for steamId, connected := range game.ReconnectedPlayers {
+		if !connected {
+			continue
+		}
 		for _, player := range allPlayers {
-			if player.SteamID64 == steamId && player.Team == team.Team() && connected && !contains(teamPlayers, player) {
+			// If the player is in connectedAfterRoundStart, do not return them
+			if game.ConnectedAfterRoundStart[player.SteamID64] {
+				continue
+			}
+
+			if player.SteamID64 == steamId && player.Team == team.Team() {
+				// Check if player is already in teamPlayers
+				idx := findPlayerIndex(teamPlayers, steamId)
+				if idx != -1 {
+					// Remove the existing record
+					teamPlayers = append(teamPlayers[:idx], teamPlayers[idx+1:]...)
+				}
+				// Append the new record
 				teamPlayers = append(teamPlayers, player)
 			}
 		}

--- a/pkg/demoscrape2/parser.go
+++ b/pkg/demoscrape2/parser.go
@@ -159,6 +159,9 @@ func ProcessDemo(demo io.ReadCloser) (*Game, error) {
 	}
 
 	initRound := func() {
+		// Reset the connectedAfterRoundStart
+		game.ConnectedAfterRoundStart = make(map[uint64]bool)
+
 		game.Flags.RoundIntegrityStart = p.GameState().TotalRoundsPlayed() + 1
 		log.Debug("We are starting round", game.Flags.RoundIntegrityStart)
 
@@ -374,6 +377,9 @@ func ProcessDemo(demo io.ReadCloser) (*Game, error) {
 			// 	game.potentialRound.playerStats[player.SteamID64] = &playerStats{name: player.Name, steamID: player.SteamID64, isBot: player.IsBot, side: int(player.Team), teamENUM: int(player.Team), teamClanName: validateTeamName(game, player.TeamState.ClanName(), player.TeamState.Team()), health: 100, tradeList: make(map[uint64]int), damageList: make(map[uint64]int)}
 			// }
 			game.ReconnectedPlayers[player.SteamID64] = true
+			if game.Flags.InRound && game.Flags.IsGameLive {
+				game.ConnectedAfterRoundStart[player.SteamID64] = true
+			}
 		}
 	})
 

--- a/pkg/demoscrape2/types.go
+++ b/pkg/demoscrape2/types.go
@@ -2,27 +2,28 @@ package demoscrape2
 
 type Game struct {
 	//winnerID         int
-	CoreID             string                  `json:"coreID"`
-	MapNum             int                     `json:"mapNum"`
-	WinnerClanName     string                  `json:"winnerClanName"`
-	Result             string                  `json:"result"`
-	Rounds             []*round                `json:"rounds"`
-	PotentialRound     *round                  `json:"potentialRound"`
-	Teams              map[string]*team        `json:"teams"`
-	Flags              flag                    `json:"flags"`
-	MapName            string                  `json:"mapName"`
-	TickRate           int                     `json:"tickRate"`
-	TickLength         int                     `json:"tickLength"`
-	RoundsToWin        int                     `json:"roundsToWin"` //30 or 16
-	TotalPlayerStats   map[uint64]*playerStats `json:"totalPlayerStats"`
-	CtPlayerStats      map[uint64]*playerStats `json:"ctPlayerStats"`
-	TPlayerStats       map[uint64]*playerStats `json:"TPlayerStats"`
-	TotalTeamStats     map[string]*teamStats   `json:"totalTeamStats"`
-	ReconnectedPlayers map[uint64]bool         `json:"reconnectedPlayers"` // Map of SteamID to reconnection status
-	PlayerOrder        []uint64                `json:"playerOrder"`
-	TeamOrder          []string                `json:"teamOrder"`
-	TotalRounds        int                     `json:"totalRounds"`
-	TotalWPAlog        []*wpalog               `json:"totalWPAlog"`
+	CoreID                   string                  `json:"coreID"`
+	MapNum                   int                     `json:"mapNum"`
+	WinnerClanName           string                  `json:"winnerClanName"`
+	Result                   string                  `json:"result"`
+	Rounds                   []*round                `json:"rounds"`
+	PotentialRound           *round                  `json:"potentialRound"`
+	Teams                    map[string]*team        `json:"teams"`
+	Flags                    flag                    `json:"flags"`
+	MapName                  string                  `json:"mapName"`
+	TickRate                 int                     `json:"tickRate"`
+	TickLength               int                     `json:"tickLength"`
+	RoundsToWin              int                     `json:"roundsToWin"` //30 or 16
+	TotalPlayerStats         map[uint64]*playerStats `json:"totalPlayerStats"`
+	CtPlayerStats            map[uint64]*playerStats `json:"ctPlayerStats"`
+	TPlayerStats             map[uint64]*playerStats `json:"TPlayerStats"`
+	TotalTeamStats           map[string]*teamStats   `json:"totalTeamStats"`
+	ReconnectedPlayers       map[uint64]bool         `json:"reconnectedPlayers"`       // Map of SteamID to reconnection status
+	ConnectedAfterRoundStart map[uint64]bool         `json:"ConnectedAfterRoundStart"` // Map of SteamID to reconnection status
+	PlayerOrder              []uint64                `json:"playerOrder"`
+	TeamOrder                []string                `json:"teamOrder"`
+	TotalRounds              int                     `json:"totalRounds"`
+	TotalWPAlog              []*wpalog               `json:"totalWPAlog"`
 }
 
 type flag struct {


### PR DESCRIPTION
Our workaround to players not being labeled as connected had a bug in which players who reconnected midround in this state would show up in team members (and would be alive). We now handle this properly and do not add midround rejoins to be returned in the team members in the same round.

Paired with Dibes while he drove.