### PR TITLE
Add RoundEndReason and Remove Invalid Rounds

### DIFF
--- a/pkg/demoscrape2/helpers.go
+++ b/pkg/demoscrape2/helpers.go
@@ -190,6 +190,30 @@ func playersWithArmor(game *Game, team *common.TeamState, p dem.Parser) int {
 	return armor
 }
 
+var roundEndReasons = map[int]string{
+	0:  "StillInProgress", //base values
+	1:  "TargetBombed",
+	2:  "VIPEscaped",
+	3:  "VIPKilled",
+	4:  "TerroristsEscaped",
+	5:  "CTStoppedEscape",
+	6:  "TerroristsStopped",
+	7:  "BombDefused",
+	8:  "CTWin",
+	9:  "TerroristsWin",
+	10: "Draw",
+	11: "HostagesRescued",
+	12: "TargetSaved",
+	13: "HostagesNotRescued",
+	14: "TerroristsNotEscaped",
+	15: "VIPNotEscaped",
+	16: "GameStart",
+	17: "TerroristsSurrender",
+	18: "CTSurrender",
+	19: "TerroristsPlanted",
+	20: "CTsReachedHostage",
+}
+
 func getPlayerAPIDict(side string, player *playerStats) Dictionary {
 
 	return Dictionary{

--- a/pkg/demoscrape2/parser.go
+++ b/pkg/demoscrape2/parser.go
@@ -585,7 +585,7 @@ func ProcessDemo(demo io.ReadCloser) (*Game, error) {
 			//we want to actually process the round
 			if game.Flags.IsGameLive && validWinner && game.Flags.RoundIntegrityStart == p.GameState().TotalRoundsPlayed() {
 				game.PotentialRound.WinnerENUM = int(e.Winner)
-				game.PotentialRound.RoundEndReason = int(e.Reason)
+				game.PotentialRound.RoundEndReason = roundEndReasons[int(e.Reason)]
 				processRoundOnWinCon(validateTeamName(game, e.WinnerState.ClanName(), e.WinnerState.Team()))
 
 				//check last round

--- a/pkg/demoscrape2/parser.go
+++ b/pkg/demoscrape2/parser.go
@@ -585,6 +585,7 @@ func ProcessDemo(demo io.ReadCloser) (*Game, error) {
 			//we want to actually process the round
 			if game.Flags.IsGameLive && validWinner && game.Flags.RoundIntegrityStart == p.GameState().TotalRoundsPlayed() {
 				game.PotentialRound.WinnerENUM = int(e.Winner)
+				game.PotentialRound.RoundEndReason = int(e.Reason)
 				processRoundOnWinCon(validateTeamName(game, e.WinnerState.ClanName(), e.WinnerState.Team()))
 
 				//check last round

--- a/pkg/demoscrape2/types.go
+++ b/pkg/demoscrape2/types.go
@@ -112,6 +112,7 @@ type round struct {
 	ServerNormalizer   int     `json:"serverNormalizer"`
 	ServerImpactPoints float64 `json:"serverImpactPoints"`
 	KnifeRound         bool    `json:"knifeRound"`
+	RoundEndReason     int     `json:"roundEndReason"`
 
 	WPAlog        []*wpalog `json:"WPAlog"`
 	BombStartTick int       `json:"bombStartTick"`

--- a/pkg/demoscrape2/types.go
+++ b/pkg/demoscrape2/types.go
@@ -112,7 +112,7 @@ type round struct {
 	ServerNormalizer   int     `json:"serverNormalizer"`
 	ServerImpactPoints float64 `json:"serverImpactPoints"`
 	KnifeRound         bool    `json:"knifeRound"`
-	RoundEndReason     int     `json:"roundEndReason"`
+	RoundEndReason     string  `json:"roundEndReason"`
 
 	WPAlog        []*wpalog `json:"WPAlog"`
 	BombStartTick int       `json:"bombStartTick"`


### PR DESCRIPTION
Rounds in a game included any round captured by the parser. Only valid rounds were included in stats calculations, but rounds itself was not sanitized. Now rounds only includes valid rounds (no knife/veto rounds, no match medic'd rounds, no incomplete rounds, etc if they managed to still be saved). I believe incomplete rounds were already filtered out.

RoundEndReason is now captured from the demo. If a round ends successfully we should get an int representing the reason for the round ending.