### PR TITLE
Bugs/handle playout scrim server match

### DIFF
--- a/pkg/demoscrape2/helpers.go
+++ b/pkg/demoscrape2/helpers.go
@@ -103,11 +103,11 @@ func validateTeamName(game *Game, teamName string, teamNum common.Team) string {
 		//we are hardcoding during what rounds each team will have what side
 		round := game.PotentialRound.RoundNum
 		swap := false
-		if round >= 16 && round <= 33 {
+		if round >= MR+1 && round <= (MR*2)+3 {
 			swap = true
-		} else if round >= 34 {
+		} else if round >= (MR*2)+4 {
 			//we are now in OT hell :)
-			if (round-34)/6%2 != 0 {
+			if (round-((MR*2)+4))/6%2 != 0 {
 				swap = true
 			}
 		}

--- a/pkg/demoscrape2/parser.go
+++ b/pkg/demoscrape2/parser.go
@@ -954,12 +954,12 @@ func ProcessDemo(demo io.ReadCloser) (*Game, error) {
 		//log.Debug("Player Flashed")
 		if game.Flags.IsGameLive && e.Player != nil && e.Attacker != nil {
 			tick := float64(p.GameState().IngameTick())
-			blindTicks := e.FlashDuration().Seconds() * 128.0
+			blindTicks := e.FlashDuration().Seconds() * float64(game.TickRate)
 			victim := e.Player
 			flasher := e.Attacker
-			if flasher.Team != victim.Team && blindTicks > 128.0 && victim.IsAlive() && (float64(victim.FlashDuration) < (blindTicks/128.0 + 1)) {
+			if flasher.Team != victim.Team && blindTicks > float64(game.TickRate) && victim.IsAlive() && (float64(victim.FlashDuration) < (blindTicks/float64(game.TickRate) + 1)) {
 				game.PotentialRound.PlayerStats[flasher.SteamID64].Ef += 1
-				game.PotentialRound.PlayerStats[flasher.SteamID64].EnemyFlashTime += (blindTicks / 128.0)
+				game.PotentialRound.PlayerStats[flasher.SteamID64].EnemyFlashTime += (blindTicks / float64(game.TickRate))
 				if tick+blindTicks > game.PotentialRound.PlayerStats[victim.SteamID64].MostRecentFlashVal {
 					game.PotentialRound.PlayerStats[victim.SteamID64].MostRecentFlashVal = tick + blindTicks
 					game.PotentialRound.PlayerStats[victim.SteamID64].MostRecentFlasher = flasher.SteamID64

--- a/pkg/demoscrape2/parser.go
+++ b/pkg/demoscrape2/parser.go
@@ -46,6 +46,7 @@ const printDebugLog = true
 const FORCE_NEW_STATS_UPLOAD = false
 const ENABLE_WPA_DATA_OUTPUT = false
 const BACKEND_PUSHING = true
+const MR = 12
 
 const tradeCutoff = 4 // in seconds
 var multiKillBonus = [...]float64{0, 0, 0.3, 0.7, 1.2, 2}
@@ -129,7 +130,7 @@ func ProcessDemo(demo io.ReadCloser) (*Game, error) {
 		game.Teams[validateTeamName(game, teamTemp.ClanName(), teamTemp.Team())] = &team{Name: validateTeamName(game, teamTemp.ClanName(), teamTemp.Team())}
 
 		//only handling normal length matches
-		game.RoundsToWin = 13
+		game.RoundsToWin = MR + 1
 
 	}
 
@@ -969,10 +970,6 @@ func ProcessDemo(demo io.ReadCloser) (*Game, error) {
 
 		}
 		//log.Debug("Player Flashed", blindTicks, e.Attacker)
-	})
-
-	p.RegisterEventHandler(func(e events.RoundImpactScoreData) {
-		log.Debug("-------ROUNDIMPACTSCOREDATA", e.RawMessage)
 	})
 
 	p.RegisterEventHandler(func(e events.BombPlanted) {

--- a/pkg/demoscrape2/parser.go
+++ b/pkg/demoscrape2/parser.go
@@ -222,10 +222,7 @@ func ProcessDemo(demo io.ReadCloser) (*Game, error) {
 		game.Flags.InRound = false
 		game.PotentialRound.EndingTick = p.GameState().IngameTick()
 		game.Flags.RoundIntegrityEndOfficial = p.GameState().TotalRoundsPlayed()
-		if lastRound {
-			//game.Flags.RoundIntegrityEndOfficial += 1
-			game.TotalRounds = game.Flags.RoundIntegrityEndOfficial
-		}
+
 		log.Debug("We are processing round final stuff", game.Flags.RoundIntegrityEndOfficial)
 		log.Debug(len(game.Rounds))
 
@@ -360,6 +357,11 @@ func ProcessDemo(demo io.ReadCloser) (*Game, error) {
 			//add our valid round
 			game.Rounds = append(game.Rounds, game.PotentialRound)
 		}
+		if lastRound {
+			//game.Flags.RoundIntegrityEndOfficial += 1
+			game.TotalRounds = game.Flags.RoundIntegrityEndOfficial
+			game.Flags.IsGameLive = false
+		}
 
 		//endRound function functionality
 
@@ -419,7 +421,7 @@ func ProcessDemo(demo io.ReadCloser) (*Game, error) {
 		}
 
 		//add to WPAlog
-		if game.Flags.InRound && !game.Flags.PostWinCon && ENABLE_WPA_DATA_OUTPUT {
+		if game.Flags.IsGameLive && game.Flags.InRound && !game.Flags.PostWinCon && ENABLE_WPA_DATA_OUTPUT {
 			//hits every new frame (typically each 1-4 ticks)
 			logSize := len(game.PotentialRound.WPAlog)
 			clock := 0
@@ -469,7 +471,7 @@ func ProcessDemo(demo io.ReadCloser) (*Game, error) {
 			}
 		}
 
-		if game.Flags.InRound && game.Flags.LastTickProcessed+(4*game.TickRate) < p.GameState().IngameTick() {
+		if game.Flags.IsGameLive && game.Flags.InRound && game.Flags.LastTickProcessed+(4*game.TickRate) < p.GameState().IngameTick() {
 			game.Flags.LastTickProcessed = p.GameState().IngameTick()
 			game.Flags.TicksProcessed += 1
 


### PR DESCRIPTION
Unnamed teams are now swapped based on MR12 instead of MR15.

An official match that is played on a scrim server will now end once enough rounds have been won instead of relying on the match to end.

Flashes now use 64 tick instead of 128 tick for timings.