### PR TITLE
Handle redone rounds ending match

### DIFF
--- a/pkg/demoscrape2/endOfMatchProcessing.go
+++ b/pkg/demoscrape2/endOfMatchProcessing.go
@@ -11,12 +11,16 @@ func removeInvalidRounds(game *Game) {
 	//we want to remove bad rounds (knife/veto rounds, incomplete rounds, redo rounds)
 	validRoundsMap := make(map[int8]bool)
 	validRounds := make([]*round, 0)
+	lastProcessedRoundNum := game.Rounds[len(game.Rounds)-1].RoundNum + 1
 	for i := len(game.Rounds) - 1; i >= 0; i-- {
 		_, validRoundExists := validRoundsMap[game.Rounds[i].RoundNum]
 		if game.Rounds[i].IntegrityCheck && !game.Rounds[i].KnifeRound && !validRoundExists {
-			//this i-th round is good to add
-			validRoundsMap[game.Rounds[i].RoundNum] = true
-			validRounds = append(validRounds, game.Rounds[i])
+			if game.Rounds[i].RoundNum == lastProcessedRoundNum-1 {
+				//this i-th round is good to add
+				validRoundsMap[game.Rounds[i].RoundNum] = true
+				validRounds = append(validRounds, game.Rounds[i])
+				lastProcessedRoundNum = game.Rounds[i].RoundNum
+			}
 		} else {
 			//this i-th round is bad and we will remove it
 		}

--- a/pkg/demoscrape2/parser.go
+++ b/pkg/demoscrape2/parser.go
@@ -504,12 +504,14 @@ func ProcessDemo(demo io.ReadCloser) (*Game, error) {
 					if terrorist.IsAlive() {
 						if game.PotentialRound.PlayerStats[terrorist.SteamID64] == nil {
 							log.Debug(terrorist.Name)
+						} else {
+							dist := game.PotentialRound.PlayerStats[terrorist.SteamID64].DistanceToTeammates
+							if dist < lurkerDist && dist > 0 {
+								lurkerDist = dist
+								lurkerSteam = terrorist.SteamID64
+							}
 						}
-						dist := game.PotentialRound.PlayerStats[terrorist.SteamID64].DistanceToTeammates
-						if dist < lurkerDist && dist > 0 {
-							lurkerDist = dist
-							lurkerSteam = terrorist.SteamID64
-						}
+
 					}
 				}
 				if lurkerSteam != 0 {

--- a/pkg/demoscrape2/parser.go
+++ b/pkg/demoscrape2/parser.go
@@ -650,6 +650,16 @@ func ProcessDemo(demo io.ReadCloser) (*Game, error) {
 		//CS2 swapped this event to be before RoundEnd
 		//We have relied on this as a back up for failed RoundEnd events
 		//may revisit depending on event reliability
+
+		//added to ensure that a bad round that gets finished does not premuturely finish the game since we track score separately
+		if game.Flags.IsGameLive {
+			//we take the existing preupdate score of the updating team score
+			updatedTeam := game.Teams[validateTeamName(game, e.TeamState.ClanName(), e.TeamState.Team())]
+			//and compare to the old score from scoreboard
+			if e.OldScore != updatedTeam.Score {
+				updatedTeam.Score = e.OldScore
+			}
+		}
 	})
 
 	//round end official doesnt fire on the last round


### PR DESCRIPTION
Currently bad rounds (ex. match medic) are "handled" by iterating through all completed rounds in reverse order, in which case the last instance of a round being completed (say round 10) is the one kept. A different round 10 that is earlier in the demo will be discarded. Regardless of which version of round 10 is the correct one.

This fix changes that logic to only accept the immediately preceding round number (ex. after processing round 30 rounds are discarded until round 29 is found and then processed).

This fix also updates the manual score to the game's score whenever the ScoreUpdated event fires if there is a mismatch. This was an issue because the score is tracked manually, and until the match is over, a (bad) round that is completed will impact the score. And if the score would end the game, the game might end prematurely. (This requires the ScoreUpdated event to fire before other RoundEnd events which is true for CS2 demos, but not true for CSGO demos).

There is also a small update to null checking in the lurker logic.

_Fixes 3663 and 3197_

Unaddressed theoretical issues:
- A demo which reaches a winning scoreline multiple times in a single demo (parser will stop on the first winning scoreline) but seems rare enough to ignore
- A bad round which is completed after the valid one and happens to be the predecessor to the highest completed round.